### PR TITLE
解决引用本地sdk,java命令报错问题

### DIFF
--- a/yuzi-generator-basic/pom.xml
+++ b/yuzi-generator-basic/pom.xml
@@ -12,6 +12,8 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- 装配的地址 -->
+        <assembly>src/main/resources/assembly.xml</assembly>
     </properties>
 
     <dependencies>
@@ -61,9 +63,9 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.3.0</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
+<!--                    <descriptorRefs>-->
+<!--                        <descriptorRef>jar-with-dependencies</descriptorRef>-->
+<!--                    </descriptorRefs>-->
                     <archive>
                         <manifest>
                             <mainClass>com.yupi.Main</mainClass> <!-- 替换为你的主类的完整类名 -->
@@ -76,6 +78,12 @@
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <configuration>
+                            <!-- assembly.xml -->
+                            <descriptors>
+                                <descriptor>${assembly}</descriptor>
+                            </descriptors>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/yuzi-generator-basic/src/main/resources/assembly.xml
+++ b/yuzi-generator-basic/src/main/resources/assembly.xml
@@ -1,0 +1,23 @@
+<assembly>
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <!-- 增加scope类型为system的配置 -->
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>system</scope>
+        </dependencySet>
+        <!-- 默认的配置 -->
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>


### PR DESCRIPTION
问题描述：使用自己的工具类，maven插件不会一起打进jar包。
解决方法：修改pom.xml中的jar-with-dependencies的作用范围，解决执行jar包报错问题。